### PR TITLE
Fixed the missing description and version in dynacli entrypoint

### DIFF
--- a/src/dynacli/bootstrap/_cli.py
+++ b/src/dynacli/bootstrap/_cli.py
@@ -7,6 +7,7 @@ DynaCLI bootstrap script
 import os
 import sys
 
+from dynacli import __version__ as _version
 from dynacli import main as dynamain
 
 cwd = os.path.dirname(os.path.realpath(__file__))
@@ -15,8 +16,25 @@ search_path = [cwd]
 sys.path.extend(search_path)
 
 
+# This fix is for dynacli entrypoint script; as it has wrapper __main__ we need to add necessary information
+
+_map = {
+    "__version__": _version,
+    "__doc__": """
+DynaCLI bootstrap script
+""",
+}
+
+
+def _set_main_attrs(**kwargs):
+    _main = sys.modules["__main__"]
+    for key, val in kwargs.items():
+        setattr(_main, key, val)
+
+
 # For package distro purposes
 def main():
+    _set_main_attrs(**_map)
     dynamain(search_path)
 
 


### PR DESCRIPTION
# Change Summary

## Description

The fix is to introduce a new map of missing description and the version to the entrypoint's(wrapper's) `__main__` module.
The most quick fix is to set module attributes `__version__` and `__doc__` in runtime, i.e setting attributes while running actual main function of the entrypoint.

Fixes #85 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

