### PR TITLE
Added check if the imported module comes from public path or not

### DIFF
--- a/src/dynacli/dynacli.py
+++ b/src/dynacli/dynacli.py
@@ -135,6 +135,10 @@ def _is_public(name: str) -> bool:
     return not name.startswith("_")
 
 
+def _is_from_public_path(name: str) -> bool:
+    return all(not _name.startswith("_") for _name in name.split("."))
+
+
 def _is_callable(command: object) -> bool:
     return isinstance(command, Callable)
 
@@ -447,14 +451,16 @@ class _ArgParsingContext:
     def _add_known_functions(self):
         for name in self._known_names:
             module = self._current_package.__dict__[name]
-            if _is_callable(module):
+            if _is_callable(module) and _is_from_public_path(module.__module__):
                 self.add_command_parser(name, self._current_package)
 
     def _add_known_modules(self):
         for name in self._known_names:
             module = self._current_package.__dict__[name]
-            if not _is_callable(module) and _is_module_shortcut(
-                name, self._current_package
+            if (
+                not _is_callable(module)
+                and _is_module_shortcut(name, self._current_package)
+                and _is_from_public_path(module.__package__)
             ):
                 self.add_feature_parser(name, module)
 

--- a/test/integrated/storage_Z/cli/dev/_common/__init__.py
+++ b/test/integrated/storage_Z/cli/dev/_common/__init__.py
@@ -1,0 +1,3 @@
+"""
+Common things should go here
+"""

--- a/test/integrated/storage_Z/cli/dev/_common/session.py
+++ b/test/integrated/storage_Z/cli/dev/_common/session.py
@@ -1,0 +1,10 @@
+def get_session(name: str) -> str:
+    """
+    Start the session
+
+    Args:
+       name (str): the session name
+
+    Return: None
+    """
+    return name

--- a/test/integrated/storage_Z/cli/dev/feature_C/__init__.py
+++ b/test/integrated/storage_Z/cli/dev/feature_C/__init__.py
@@ -2,8 +2,13 @@
 Awesome
 """
 
+# This will be ignored as well as it does not come from the search_path/root_package
+from os.path import join
+from typing import Type
+
 # This imported function should be ignored as it is not from the public path
 from .._common.session import get_session
+from ..feature_A.feature_B.create import create
 from .feature_F import service
 from .feature_F.service import new
 

--- a/test/integrated/storage_Z/cli/dev/feature_C/__init__.py
+++ b/test/integrated/storage_Z/cli/dev/feature_C/__init__.py
@@ -2,5 +2,14 @@
 Awesome
 """
 
+# This imported function should be ignored as it is not from the public path
+from .._common.session import get_session
 from .feature_F import service
 from .feature_F.service import new
+
+
+# So you can use any kind of common functionality here.
+# We consider the imported functionality as nested feature commands if it came from public path.
+# Otherwise, it will be ignored and will not be exposed in CLI.
+def _use_session():
+    get_session("fake session")

--- a/test/integrated/suite/testclinested feature-C -h
+++ b/test/integrated/suite/testclinested feature-C -h
@@ -1,10 +1,11 @@
-usage: testclinested feature-C [-h] {feature-F,new,service} ...
+usage: testclinested feature-C [-h] {feature-F,new,create,service} ...
 
 positional arguments:
-  {feature-F,new,service}
+  {feature-F,new,create,service}
     feature-F           The awesome feature-F
     new                 Creates a new service - example of directly importing
                         module in __init__.py
+    create              create the project and its libraries
     service             This is an example of module - which is imported in
                         __init__.py
 

--- a/test/integrated/suite/testclinested feature-C -h
+++ b/test/integrated/suite/testclinested feature-C -h
@@ -1,11 +1,11 @@
-usage: testclinested feature-C [-h] {feature-F,new,create,service} ...
+usage: testclinested feature-C [-h] {feature-F,create,new,service} ...
 
 positional arguments:
-  {feature-F,new,create,service}
+  {feature-F,create,new,service}
     feature-F           The awesome feature-F
+    create              create the project and its libraries
     new                 Creates a new service - example of directly importing
                         module in __init__.py
-    create              create the project and its libraries
     service             This is an example of module - which is imported in
                         __init__.py
 

--- a/test/integrated/test_dynacli.py
+++ b/test/integrated/test_dynacli.py
@@ -1,7 +1,6 @@
 import os
 import sys
 import unittest
-from contextlib import contextmanager
 from os import environ, path
 from subprocess import run
 from typing import Tuple, Union
@@ -17,8 +16,13 @@ skip_ = {
         "[colors ...]",
         "[x ...]",
         "[args ...]",
+        "usage: testclinested feature-C [-h] {feature-F,create,new,service}",
+        "usage: testclinested feature-C [-h] {feature-F,new,create,service}",
     ],
-    PY39: [],
+    PY39: [
+        "usage: testclinested feature-C [-h] {feature-F,create,new,service}",
+        "usage: testclinested feature-C [-h] {feature-F,new,create,service}",
+    ],
 }
 
 


### PR DESCRIPTION
# Change Summary

## Description
Importing public functions from non-public paths will be ignored and not registered in CLI.
If the imports are from the public paths they will be exposed as nested features in CLI.

Fixes #94 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

